### PR TITLE
Removed dependency to call Resume to either new up model or populate from json.

### DIFF
--- a/Bootstrap/Program.cs
+++ b/Bootstrap/Program.cs
@@ -20,8 +20,9 @@ namespace Bootstrap
             var dispatcher = new EventDispatcher();
             var processor = new PaymentsByCustomerByDateProcessor(modelStore);
 
+            var resumeFrom = processor.ResumeFrom;
             processor.Register(dispatcher);
-            dispatcher.Dispatch(source.Read(processor.Resume()));
+            dispatcher.Dispatch(source.Read(resumeFrom));
 
             PrintWinners(processor.GetHighestPayingCustomers());
         }

--- a/ReadModel/PaymentsByCustomerByDateProcessor.cs
+++ b/ReadModel/PaymentsByCustomerByDateProcessor.cs
@@ -1,7 +1,6 @@
 ﻿using ReadModel.Events;
 using System;
 using System.Collections.Generic;
-using ReadModel.Models;
 using ReadModel.Models.CustomerPayment;
 
 namespace ReadModel
@@ -11,13 +10,15 @@ namespace ReadModel
         private readonly IPersist _modelStore;
         private PaymentsByCustomerByDateModel _model;
         private const string Filename = "PaymentsByCustomerByDate.json";
+        public long ResumeFrom { get; }
         
         public PaymentsByCustomerByDateProcessor(IPersist modelStore)
         {
             _modelStore = modelStore;
+            ResumeFrom = Resume();
         }
 
-        public long Resume()
+        private long Resume()
         {
             _model = _modelStore.IsFileExists(Filename)
                 ? _modelStore.Read<PaymentsByCustomerByDateModel>(Filename)


### PR DESCRIPTION
Resume now called in processor constructor, stops null exception. ResumeFrom passed to IDataSource.Read() to allow resuming from last sequenceId from json file.

Unit tests updated, Teardown disposable clears files/folders created during tests.